### PR TITLE
AT-77-no-data-gender-background

### DIFF
--- a/spec/unit/backgroundObject.spec.js
+++ b/spec/unit/backgroundObject.spec.js
@@ -5,33 +5,31 @@ const createStudents = require('../../test/ReportGroupTests/create-students')
 const backgroundRatio = require('../../src/reports/backgroundRatio');
 const nodataStudents = require('../../test/ReportGroupTests/create-students-nodata')
 describe('background ratio test', () => {
-  let cohortId
-  let backgroundArr
+  let cohortId, backgrounds
   beforeEach( async () => { 
     await truncateTables()
     await createCohorts()
     await createStudents()
     cohortId = 1;
-    backgroundArr = await backgroundRatio(cohortId);
+    backgrounds = await backgroundRatio(cohortId);
    })
   it('calculates background ratio from background data', async () => {
-    expect(backgroundArr[0].percentage).toEqual('25.00');
-    expect(backgroundArr[1].percentage).toEqual('50.00');
+    expect(backgrounds[0].percentage).toEqual('25.00');
+    expect(backgrounds[1].percentage).toEqual('50.00');
   });
 });
 describe('testing students with no data', function() {
-  let cohortId
-  let backgroundArr
+  let cohortId, backgrounds
   beforeEach( async () => { 
     await truncateTables()
     await createCohorts()
     await nodataStudents()
     cohortId = 1;
-    backgroundArr = await backgroundRatio(cohortId);
+    backgrounds = await backgroundRatio(cohortId);
    })
   it('calculates background ratio from background data when one student has no background data', async () => {
-    expect(backgroundArr[1].type).toEqual('no data')
-    expect(backgroundArr[1].number).toEqual(1)
-    expect(backgroundArr[1].percentage).toEqual('50.00')
+    expect(backgrounds[1].type).toEqual('no data')
+    expect(backgrounds[1].number).toEqual(1)
+    expect(backgrounds[1].percentage).toEqual('50.00')
   });
 })

--- a/spec/unit/backgroundObject.spec.js
+++ b/spec/unit/backgroundObject.spec.js
@@ -3,6 +3,7 @@ const truncateTables = require('../../test/ReportGroupTests/truncate-tables')
 const createCohorts = require('../../test/ReportGroupTests/create-cohorts')
 const createStudents = require('../../test/ReportGroupTests/create-students')
 const backgroundRatio = require('../../src/reports/backgroundRatio');
+const nodataStudents = require('../../test/ReportGroupTests/create-students-nodata')
 describe('background ratio test', () => {
   let cohortId
   let backgroundArr
@@ -18,3 +19,19 @@ describe('background ratio test', () => {
     expect(backgroundArr[1].percentage).toEqual('50.00');
   });
 });
+describe('testing students with no data', function() {
+  let cohortId
+  let backgroundArr
+  beforeEach( async () => { 
+    await truncateTables()
+    await createCohorts()
+    await nodataStudents()
+    cohortId = 1;
+    backgroundArr = await backgroundRatio(cohortId);
+   })
+  it('calculates background ratio from background data when one student has no background data', async () => {
+    expect(backgroundArr[1].type).toEqual('no data')
+    expect(backgroundArr[1].number).toEqual(1)
+    expect(backgroundArr[1].percentage).toEqual('50.00')
+  });
+})

--- a/spec/unit/genderObject.spec.js
+++ b/spec/unit/genderObject.spec.js
@@ -5,35 +5,33 @@ const createStudents = require('../../test/ReportGroupTests/create-students')
 const genderRatio = require('../../src/reports/genderRatio');
 const nodataStudents = require('../../test/ReportGroupTests/create-students-nodata')
 describe('gender ratio test', () => {
-  let cohortId
-  let gendersArr
+  let cohortId, genders
   beforeEach( async () => { 
     await truncateTables()
     await createCohorts()
     await createStudents()
     cohortId = 1;
-    gendersArr = await genderRatio(cohortId);
+    genders = await genderRatio(cohortId);
    })
   it('calculates gender ratio from gender data', async () => {
-    expect(gendersArr[1].type).toEqual('female')
-    expect(gendersArr[1].number).toEqual(3)
-    expect(gendersArr[0].percentage).toEqual('25.00')
+    expect(genders[1].type).toEqual('female')
+    expect(genders[1].number).toEqual(3)
+    expect(genders[0].percentage).toEqual('25.00')
   });
 });
 
 describe('testing students with no data', function() {
-  let cohortId
-  let gendersArr
+  let cohortId, genders
   beforeEach( async () => { 
     await truncateTables()
     await createCohorts()
     await nodataStudents()
     cohortId = 1;
-    gendersArr = await genderRatio(cohortId);
+    genders = await genderRatio(cohortId);
    })
   it('calculates gender ratio from gender data when one student has no gender data', async () => {
-    expect(gendersArr[0].type).toEqual('no data')
-    expect(gendersArr[0].number).toEqual(1)
-    expect(gendersArr[0].percentage).toEqual('50.00')
+    expect(genders[0].type).toEqual('no data')
+    expect(genders[0].number).toEqual(1)
+    expect(genders[0].percentage).toEqual('50.00')
   });
 })

--- a/spec/unit/genderObject.spec.js
+++ b/spec/unit/genderObject.spec.js
@@ -3,6 +3,7 @@ const truncateTables = require('../../test/ReportGroupTests/truncate-tables')
 const createCohorts = require('../../test/ReportGroupTests/create-cohorts')
 const createStudents = require('../../test/ReportGroupTests/create-students')
 const genderRatio = require('../../src/reports/genderRatio');
+const nodataStudents = require('../../test/ReportGroupTests/create-students-nodata')
 describe('gender ratio test', () => {
   let cohortId
   let gendersArr
@@ -19,3 +20,20 @@ describe('gender ratio test', () => {
     expect(gendersArr[0].percentage).toEqual('25.00')
   });
 });
+
+describe('testing students with no data', function() {
+  let cohortId
+  let gendersArr
+  beforeEach( async () => { 
+    await truncateTables()
+    await createCohorts()
+    await nodataStudents()
+    cohortId = 1;
+    gendersArr = await genderRatio(cohortId);
+   })
+  it('calculates gender ratio from gender data when one student has no gender data', async () => {
+    expect(gendersArr[0].type).toEqual('no data')
+    expect(gendersArr[0].number).toEqual(1)
+    expect(gendersArr[0].percentage).toEqual('50.00')
+  });
+})

--- a/src/reports/backgroundRatio.js
+++ b/src/reports/backgroundRatio.js
@@ -9,12 +9,8 @@ const backgroundRatio = async (cohortId) => {
     }
   });
   const total = backgroundQuery.count 
-  const backgrounds = backgroundQuery.rows.map(row => row.background)
-  for (let i=0; i < backgrounds.length; i++) {
-    if (backgrounds[i] === null) {
-      backgrounds[i] = 'no data'
-    }
-  }
+  let backgrounds = backgroundQuery.rows.map(row => row.background)
+  backgrounds = backgrounds.map(background => (background === null) ? 'no data' : background)
   const backgroundObj = [];
   const uniquebackgrounds = backgrounds.filter((background, index) => {
     return backgrounds.indexOf(background) === index;

--- a/src/reports/backgroundRatio.js
+++ b/src/reports/backgroundRatio.js
@@ -10,6 +10,11 @@ const backgroundRatio = async (cohortId) => {
   });
   const total = backgroundQuery.count 
   const backgrounds = backgroundQuery.rows.map(row => row.background)
+  for (let i=0; i < backgrounds.length; i++) {
+    if (backgrounds[i] === null) {
+      backgrounds[i] = 'no data'
+    }
+  }
   const backgroundObj = [];
   const uniquebackgrounds = backgrounds.filter((background, index) => {
     return backgrounds.indexOf(background) === index;

--- a/src/reports/genderRatio.js
+++ b/src/reports/genderRatio.js
@@ -8,16 +8,10 @@ const genderRatio = async (cohortId) => {
     }
   });
   const total = genderQuery.count 
-  const genders = genderQuery.rows.map(row => row.gender)
-  for (let i=0; i < genders.length; i++) {
-    if (genders[i] === null) {
-      genders[i] = 'no data'
-    }
-  }
+  let genders = genderQuery.rows.map(row => row.gender)
+  genders = genders.map(gender => (gender === null) ? 'no data' : gender)
   const genderObj = [];
-  const uniquegenders = genders.filter((gender, index) => {
-    return genders.indexOf(gender) === index;
-  });
+  const uniquegenders = genders.filter((gender, index) => genders.indexOf(gender) === index);
   const genderArr = [];
   uniquegenders.forEach((gender,index) => {genderArr[index] = {type: gender, number: 0, percentage: 0} });
   genders.forEach(function (gender) { genderObj[gender] = (genderObj[gender] || 0) + 1; });

--- a/src/reports/genderRatio.js
+++ b/src/reports/genderRatio.js
@@ -1,6 +1,6 @@
 const { Student } = require('../../models');
 const genderRatio = async (cohortId) => {
-  genderQuery = await Student.findAndCountAll({
+  const genderQuery = await Student.findAndCountAll({
     raw: true,
     attributes: ['gender'],
     where :{
@@ -9,6 +9,11 @@ const genderRatio = async (cohortId) => {
   });
   const total = genderQuery.count 
   const genders = genderQuery.rows.map(row => row.gender)
+  for (let i=0; i < genders.length; i++) {
+    if (genders[i] === null) {
+      genders[i] = 'no data'
+    }
+  }
   const genderObj = [];
   const uniquegenders = genders.filter((gender, index) => {
     return genders.indexOf(gender) === index;
@@ -24,5 +29,7 @@ const genderRatio = async (cohortId) => {
   }
     return genderArr;
 };
+
+genderRatio(1)
 
 module.exports = genderRatio;

--- a/src/reports/genderRatio.js
+++ b/src/reports/genderRatio.js
@@ -1,6 +1,6 @@
 const { Student } = require('../../models');
 const genderRatio = async (cohortId) => {
-  const genderQuery = await Student.findAndCountAll({
+  genderQuery = await Student.findAndCountAll({
     raw: true,
     attributes: ['gender'],
     where :{
@@ -29,7 +29,5 @@ const genderRatio = async (cohortId) => {
   }
     return genderArr;
 };
-
-genderRatio(1)
 
 module.exports = genderRatio;

--- a/test/ReportGroupTests/create-students-nodata.js
+++ b/test/ReportGroupTests/create-students-nodata.js
@@ -1,0 +1,29 @@
+const { Student } = require('../../models')
+
+const nodataStudents = async () => {
+    console.log('creating student')
+    await Student.bulkCreate( [{
+        id:6,
+        firstName: 'no gender',
+        lastName: 'Student',
+        githubUsername: 'dummy-student1',
+        email: 'dummy1@student.com',
+        createdAt: new Date('2021-01-08'),
+        updatedAt: new Date('2021-01-08'),
+        background: 'White',
+        CohortId: 1
+    },{
+        id:7,
+        firstName: 'no background',
+        lastName: 'Student',
+        githubUsername: 'dummy-student1',
+        email: 'dummy1@student.com',
+        createdAt: new Date('2021-01-08'),
+        updatedAt: new Date('2021-01-08'),
+        gender: 'male',
+        CohortId: 1
+    }
+]
+)}
+
+module.exports = nodataStudents


### PR DESCRIPTION
Co-authored-by reginmaru reginmaru@gmail.com

Jira: https://dfacademy.atlassian.net/jira/software/projects/AT/boards/4?selectedIssue=AT-77

Problem: If there was no data in the gender column of the students database, it would not be counted.

Solution: A category of 'no data' is now automatically added when a student does not have a gender in the database.

Next steps: Repeat for when a student does not have a module challenge submission. We will then update to use the constants file when this has been created.