### PR TITLE
use Promise.all to build object response

### DIFF
--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -11,7 +11,7 @@ describe('Dashboard Router Test', () => {
   it('returns dashboard object', () => {
     cy.request('GET', '/api/dashboard').then(
       (res) => {
-        expect(res.body).to.have.property('dashboard') 
+        expect(res.body).to.have.property('dashboard')
       }
     )
   });
@@ -32,13 +32,13 @@ describe('Dashboard Router Test', () => {
   it('returns correct students total', () => {
     cy.request('GET', '/api/dashboard').then( (res) => {
       expect(res.body.dashboard.studentTotal).to.eq(5)
-    })    
+    })
   })
 
   it('returns correct cohorts total', () => {
     cy.request('GET', '/api/dashboard').then( (res) => {
       expect(res.body.dashboard.cohortsTotal).to.eq(3)
-    })    
+    })
   })
 
    it('returns correct gender object', () => {
@@ -46,7 +46,7 @@ describe('Dashboard Router Test', () => {
       expect(res.body.dashboard.gender.length).to.eq( 2);
       expect(res.body.dashboard.gender[0]).to.deep.eq({type: 'male', number: 1, percentage: '20.00'})
       expect(res.body.dashboard.gender[1]).to.deep.eq({type: 'female', number: 4, percentage: '80.00'})
-    })    
+    })
   })
 
   it('returns correct background object', () => {
@@ -54,8 +54,8 @@ describe('Dashboard Router Test', () => {
       expect(res.body.dashboard.background.length).to.eq( 3)
       expect(res.body.dashboard.background[0]).to.deep.eq({type: 'White', number: 1, percentage: '20.00'})
       expect(res.body.dashboard.background[1]).to.deep.eq({type: 'Black', number: 2, percentage: '40.00'})
-      expect(res.body.dashboard.background[2]).to.deep.eq({type: 'Other', number: 2, percentage: '40.00'})  
-    })    
+      expect(res.body.dashboard.background[2]).to.deep.eq({type: 'Other', number: 2, percentage: '40.00'})
+    })
   })
 
   it('returns correct challenges object', () => {
@@ -67,5 +67,5 @@ describe('Dashboard Router Test', () => {
   })
 
 
-  
+
 });

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -16,6 +16,7 @@ class Dashboard {
         .then(values => {
           values.forEach(value => Object.assign(this.data, value))
         })
+      console.log(this.data)
       return this.data
     }
 }

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,8 +1,10 @@
-const backgroundRatio = require("./backgroundRatio")
-const genderRatio = require("./genderRatio")
-const challengeRatio = require('./challengeRatio')
-const countCohorts = require('./countCohorts')
-const countStudents = require('./countStudents')
+const dataPromises = [
+  require("./backgroundRatio")(),
+  require("./genderRatio")(),
+  require('./challengeRatio')(),
+  require('./countCohorts')(),
+  require('./countStudents')()
+]
 
 class Dashboard {
     constructor() {
@@ -10,13 +12,11 @@ class Dashboard {
     }
 
     async create() {
-        await countStudents().then((studentCount) => this.data['studentTotal'] = studentCount)
-        await countCohorts().then((cohortCount) => this.data['cohortsTotal'] = cohortCount)
-        await genderRatio().then((genderData) => this.data['gender'] = genderData)
-        await backgroundRatio().then((backgroundData) => this.data['background'] = backgroundData)
-        await challengeRatio().then((challengeData) => this.data['challenges'] = challengeData)
-        
-        return this.data
+      await Promise.all(dataPromises)
+        .then(values => {
+          values.forEach(value => Object.assign(this.data, value))
+        })
+      return this.data
     }
 }
 

--- a/src/dashboard/backgroundRatio.js
+++ b/src/dashboard/backgroundRatio.js
@@ -7,7 +7,7 @@ const backgroundRatio = async () => {
   });
 
   const total = backgroundQuery.count;
-  const backgrounds = backgroundQuery.rows.map(row => row.background);    
+  const backgrounds = backgroundQuery.rows.map(row => row.background);
   const uniqueBackground = backgrounds.filter((background, index) => {return index === backgrounds.indexOf(background)});
   const backgroundArr = [];
 
@@ -20,7 +20,9 @@ const backgroundRatio = async () => {
     background.percentage = (numberOfCurrentBackground.length/total*100).toFixed(2).toString();
   })
 
-  return backgroundArr
+  return {
+    background: backgroundArr
+  }
 }
 
 module.exports = backgroundRatio;

--- a/src/dashboard/challengeRatio.js
+++ b/src/dashboard/challengeRatio.js
@@ -24,7 +24,9 @@ const challengeRatio = async () => {
         challenge.percentage = (challengeComplete.length / totalChallenge.length * 100).toFixed(2).toString()
     })
 
-    return challengeArr
+    return {
+      challenges: challengeArr
+    }
 }
 
 module.exports = challengeRatio

--- a/src/dashboard/countCohorts.js
+++ b/src/dashboard/countCohorts.js
@@ -1,7 +1,9 @@
-const { Cohort } = require('../../models') 
+const { Cohort } = require('../../models')
 
 const countCohorts = async () => {
-    return await Cohort.count()
+    return {
+      cohortsTotal: await Cohort.count()
+    }
 }
 
 module.exports = countCohorts

--- a/src/dashboard/countStudents.js
+++ b/src/dashboard/countStudents.js
@@ -1,7 +1,9 @@
-const { Student } = require('../../models') 
+const { Student } = require('../../models')
 
 const countStudents = async () => {
-    return await Student.count()
+    return {
+      studentTotal: await Student.count()
+    }
 }
 
 module.exports = countStudents

--- a/src/dashboard/genderRatio.js
+++ b/src/dashboard/genderRatio.js
@@ -20,7 +20,9 @@ const genderRatio = async () => {
         gender.percentage = (numberOfCurrentGender.length / total * 100).toFixed(2).toString();
     })
 
-    return genderArr
+    return {
+      gender: genderArr
+    }
 }
 
 module.exports = genderRatio


### PR DESCRIPTION
Example refactor
- move top level response object properties back to their own responsible objects
- use `Promise.all()` to resolve all queries to get report data
- use `Object.assign()` to build response object