### PR TITLE
AT-84-file-upload-history

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -19,5 +19,9 @@ module.exports = {
     airport: "Airport",
     scrabble: "Scrabble",
     news: "News Summary Challenge"
+  },
+  fileUploadTypes: {
+    selfAssessment: "Self Assessment",
+    moduleChallenge: "Module Challenges"
   }
 };

--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -6,6 +6,7 @@ describe("Dashboard Router Test", () => {
     cy.task("taskCreateCohorts");
     cy.task("taskCreateStudents");
     cy.task("taskCreateModuleChallenges");
+    cy.task("taskCreateUploadHistory");
   });
 
 
@@ -67,6 +68,10 @@ describe("Dashboard Router Test", () => {
     });
   });
 
-
-  
+  it("returns correct fileUploads array", () => {
+    cy.request("GET", "/api/dashboard").then((res) => {
+      expect(res.body.dashboard.fileUploads[0]).to.deep.eq({type: "Self Assessment", uploads: [1,1,1,2,1,1,0]});
+      expect(res.body.dashboard.fileUploads[1]).to.deep.eq({type: "Module Challenges", uploads: [0,1,1,0,0,0,0]});
+    });
+  });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -22,6 +22,7 @@ const createStudents = require("../../test/ReportGroupTests/create-students.js")
 const createModuleChallenges = require("../../test/ReportGroupTests/create-module-challenges.js");
 const createStudent = require("../../test/StudentGroupTests/create-student.js");
 const createCohort = require("../../test/create-cohort.js");
+const createUploadHistory = require("../../test/ReportGroupTests/create-upload-history");
 
 module.exports = (on) => {
   // `on` is used to hook into various events Cypress emits
@@ -55,6 +56,11 @@ module.exports = (on) => {
     async taskCreateCohort() {
       console.log("running createStudents task");
       await createCohort();
+      return null;
+    },
+    async taskCreateUploadHistory() {
+      console.log("running CreateUploadHistory task");
+      await createUploadHistory();
       return null;
     }
   });

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -3,6 +3,7 @@ const genderRatio = require("./genderRatio");
 const challengeRatio = require("./challengeRatio");
 const countCohorts = require("./countCohorts");
 const countStudents = require("./countStudents");
+const fileUploads = require("./fileUploads");
 
 class Dashboard {
   constructor() {
@@ -15,6 +16,7 @@ class Dashboard {
     await genderRatio().then((genderData) => this.data["gender"] = genderData);
     await backgroundRatio().then((backgroundData) => this.data["background"] = backgroundData);
     await challengeRatio().then((challengeData) => this.data["challenges"] = challengeData);
+    await fileUploads().then((uploadData) => this.data["fileUploads"] = uploadData);
         
     return this.data;
   }

--- a/src/dashboard/countUploadsPerDay.js
+++ b/src/dashboard/countUploadsPerDay.js
@@ -1,0 +1,22 @@
+
+const countUploadsPerDay = (fileUploadDates, numberOfDays) => {
+  let uploads = createDatesObject(numberOfDays);
+  for (let i=0; i<fileUploadDates.length; i++) {
+    let formattedDate = fileUploadDates[i].toLocaleDateString();
+    uploads[formattedDate] += 1;
+  }
+  return Object.values(uploads).reverse();
+};
+
+const createDatesObject = (numberOfDays) => {
+  let datesObj = {};
+  for (let i=0; i<numberOfDays; i++) {
+    let date = new Date();
+    date.setDate(date.getDate() - i);
+    date = date.toLocaleDateString();
+    datesObj[date] = 0;
+  }
+  return datesObj;
+};
+
+module.exports = countUploadsPerDay;

--- a/src/dashboard/fileUploads.js
+++ b/src/dashboard/fileUploads.js
@@ -1,0 +1,31 @@
+const { UploadHistory } = require("../../models");
+const { Op } = require("sequelize");
+const countUploadsPerDay = require("./countUploadsPerDay");
+
+const fileUploads = async () => {
+  let date = new Date();
+  date.setDate(date.getDate()-6);
+  date.setUTCHours(0,0,0,0);
+
+  const uploadQuery = await UploadHistory.findAll({
+    raw: true,
+    attributes: ["uploadType", "createdAt"],
+    where: {
+      status: "success",
+      createdAt: {
+        [Op.gt]: date
+      }
+    }
+  });
+  const uploadTypes = uploadQuery.map(row => row.uploadType);
+  const uniqueUploadTypes = uploadTypes.filter((uploadType, index) => uploadTypes.indexOf(uploadType) === index);
+  const fileUploads = [];
+  for (let i=0; i<uniqueUploadTypes.length; i++) {
+    const currentTypeUploads = uploadQuery.filter((row) => row.uploadType === uniqueUploadTypes[i]).map(row => row.createdAt); 
+    let uploads = countUploadsPerDay(currentTypeUploads, 7);
+    fileUploads.push({type: uniqueUploadTypes[i], uploads: uploads});
+  }
+  return fileUploads;
+};
+
+module.exports = fileUploads;

--- a/test/ReportGroupTests/create-upload-history.js
+++ b/test/ReportGroupTests/create-upload-history.js
@@ -1,0 +1,90 @@
+const { UploadHistory } = require("../../models");
+const constants = require("../../constants");
+const createDate = (daysAgo) => {
+  let date = new Date();
+  return date.setDate(date.getDate() - daysAgo);
+};
+const createUploads = async () => {
+  console.log("creating uploads");
+  await UploadHistory.bulkCreate( [
+    {
+      id: 1,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(10),
+      updatedAt: createDate(10)
+    },
+    {
+      id: 2,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(1),
+      updatedAT: createDate(1)
+    },
+    {
+      id: 3,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(2),
+      updatedAT: createDate(2)
+    },
+    {
+      id: 4,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(3),
+      updatedAT: createDate(3)
+    },
+    {
+      id: 5,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(3),
+      updatedAT: createDate(3)
+    },
+    {
+      id: 6,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(4),
+      updatedAT: createDate(4)
+    },
+    {
+      id: 7,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(5),
+      updatedAT: createDate(5)
+    },
+    {
+      id: 8,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "success",
+      createdAt: createDate(6),
+      updatedAT: createDate(6)
+    },
+    {
+      id: 9,
+      uploadType: constants.fileUploadTypes.selfAssessment,
+      status: "failed",
+      createdAt: createDate(6),
+      updatedAT: createDate(6)
+    },
+    {
+      id: 10,
+      uploadType: constants.fileUploadTypes.moduleChallenge,
+      status: "success",
+      createdAt: createDate(5),
+      updatedAT: createDate(5)
+    },
+    {
+      id: 11,
+      uploadType: constants.fileUploadTypes.moduleChallenge,
+      status: "success",
+      createdAt: createDate(4),
+      updatedAT: createDate(4)
+    }
+  ]);
+};
+
+module.exports = createUploads;


### PR DESCRIPTION
Co-authored-by: richardtully richardtully12@gmail.com

Jira: https://dfacademy.atlassian.net/jira/software/projects/AT/boards/4?selectedIssue=AT-84

Problem:  We need to display the number of file uploads that have occurred over the last 7 days. This should be grouped by type.

Solution: We have updated the response when the user visits /dashboard so that it will contain the required data.
We query the database to find all files uploaded in the past 7 days, then transform the data into the format required by the frontend.